### PR TITLE
Add a configure script, and support builddir != srcdir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,6 @@ install: all
 	install -D -m 0755 adb/adbd $(DESTDIR)$(sbindir)
 	install -D -m 0755 adb/xdg-adbd $(DESTDIR)$(sbindir)
 	install -d -m 0755 $(DESTDIR)$(prefix)/lib/systemd/system/
-	install -D -m 0755 $(top_srcdir)/adbd.service $(DESTDIR)$(prefix)/lib/systemd/system/
+	install -D -m 0644 $(top_srcdir)/adbd.service $(DESTDIR)$(prefix)/lib/systemd/system/
 
 .PHONY: subdirs

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,53 @@
+top_srcdir ?= .
+VPATH = $(top_srcdir)
+include $(top_srcdir)/include.mk
+
+SUBDIRS= \
+	adb \
+	adb/daemon \
+	base \
+	libcrypto_utils \
+	libcutils
+
 all: adb/adbd adbd.service
 
-libcutils/libcutils.a: libcutils/*.c libcutils/*.cpp
-	make -C libcutils
+makefiles:
+	@ts=$(top_srcdir); \
+	[ "$${ts#/}" = "$$ts" ] && ts=../$$ts; \
+	if [ "$(top_srcdir)" != "." ] ; then \
+	    for d in $(SUBDIRS) ; do \
+                 mkdir -p $$d ; \
+		 if [ -e "$(top_srcdir)/$$d/Makefile" ] ; then \
+	             echo "top_srcdir=$$ts" > $$d/Makefile; \
+	             echo "top_builddir=.." >> $$d/Makefile; \
+                     echo "include \$$(top_srcdir)/$$d/Makefile" >> $$d/Makefile; \
+	         fi \
+	    done ; \
+	fi
 
-base/libbase.a: base/*.cpp
-	make -C base
+libcutils/libcutils.a: subdirs $(top_srcdir)/libcutils/*.c $(top_srcdir)/libcutils/*.cpp
+	$(MAKE) -C libcutils
 
-libcrypto_utils/libcrypto_utils.a: libcrypto_utils/android_pubkey.c
-	make -C libcrypto_utils
+base/libbase.a: subdirs $(top_srcdir)/base/*.cpp
+	$(MAKE) -C base
 
-adb/adbd adb/xdg-adbd: libcutils/libcutils.a base/libbase.a libcrypto_utils/libcrypto_utils.a adb/*.cpp adb/xdg-adbd.c
-	make -C adb
+libcrypto_utils/libcrypto_utils.a: subdirs libcrypto_utils/android_pubkey.c
+	$(MAKE) -C libcrypto_utils
 
-clean:
-	make -C libcutils clean
-	make -C base clean
-	make -C libcrypto_utils clean
-	make -C adb clean
+adb/adbd adb/xdg-adbd: subdirs libcutils/libcutils.a base/libbase.a libcrypto_utils/libcrypto_utils.a $(top_srcdir)/adb/*.cpp adb/xdg-adbd.c
+	$(MAKE) -C adb
+
+clean: subdirs
+	$(MAKE) -C libcutils clean
+	$(MAKE) -C base clean
+	$(MAKE) -C libcrypto_utils clean
+	$(MAKE) -C adb clean
 
 install: all
-	install -d -m 0755 $(DESTDIR)/$(PREFIX)/sbin
-	install -D -m 0755 adb/adbd $(DESTDIR)/$(PREFIX)/sbin/
-	install -D -m 0755 adb/xdg-adbd $(DESTDIR)/$(PREFIX)/sbin/
-	install -d -m 0755 $(DESTDIR)/$(PREFIX)/lib/systemd/system/
-	install -D -m 0755 adbd.service $(DESTDIR)/$(PREFIX)/lib/systemd/system/
+	install -d -m 0755 $(DESTDIR)$(sbindir)
+	install -D -m 0755 adb/adbd $(DESTDIR)$(sbindir)
+	install -D -m 0755 adb/xdg-adbd $(DESTDIR)$(sbindir)
+	install -d -m 0755 $(DESTDIR)$(prefix)/lib/systemd/system/
+	install -D -m 0755 $(top_srcdir)/adbd.service $(DESTDIR)$(prefix)/lib/systemd/system/
+
+.PHONY: subdirs

--- a/adb/Makefile
+++ b/adb/Makefile
@@ -85,5 +85,5 @@ xdg-adbd: xdg-adbd.c
 	gcc -o $@ $< $(CFLAGS) $(LFLAGS) `pkg-config --libs --cflags glib-2.0`
 
 clean:
-	rm -f $(LOCAL_MODULE) *.o daemon/*.o
+	rm -f $(LOCAL_MODULE) xdg-adbd *.o daemon/*.o
 

--- a/adb/Makefile
+++ b/adb/Makefile
@@ -85,5 +85,5 @@ xdg-adbd: xdg-adbd.c
 	gcc -o $@ $< $(CFLAGS) $(LFLAGS) `pkg-config --libs --cflags glib-2.0`
 
 clean:
-	rm -f $(LOCAL_MODULE) *.o
+	rm -f $(LOCAL_MODULE) *.o daemon/*.o
 

--- a/adb/Makefile
+++ b/adb/Makefile
@@ -1,6 +1,11 @@
 # makefile to build adbd natively for linux:
 
-LOCAL_PATH:= $(shell pwd)
+top_srcdir ?= ..
+srcdir = $(top_srcdir)/adb
+VPATH = $(srcdir)
+include $(top_srcdir)/include.mk
+
+LOCAL_PATH:= $(shell cd $(top_srcdir) && pwd)
 adb_version := $(shell git -C $(LOCAL_PATH) rev-parse --short=12 HEAD 2>/dev/null)-android
 
 LIBADB_SRC_FILES := \
@@ -45,11 +50,11 @@ LOCAL_SRC_FILES += \
 LOCAL_SRC_C_FILES := \
 	usb_linux_client.c
 
-LOCAL_CFLAGS := -O2 -g -DADB_HOST=0 -Wall -Wno-unused-parameter
+LOCAL_CFLAGS := -DADB_HOST=0 -Wall -Wno-unused-parameter
 LOCAL_CFLAGS += -D_XOPEN_SOURCE -D_GNU_SOURCE -DHAVE_PTHREADS=1
 LOCAL_CFLAGS += -DADB_NON_ANDROID=1 -DADB_REVISION='"$(adb_version)"'
 LOCAL_CFLAGS += -DPROP_NAME_MAX=32 -DPROP_VALUE_MAX=92 -DALLOW_ADBD_NO_AUTH=1
-LOCAL_INCLUDES := -I../include -I../base/include/ -I../libcrypto_utils/include/ -I.
+LOCAL_INCLUDES := -I$(top_srcdir)/include -I$(top_srcdir)/base/include/ -I$(top_srcdir)/libcrypto_utils/include/ -I$(srcdir)
 
 LOCAL_MODULE := adbd
 
@@ -62,8 +67,8 @@ LOCAL_STATIC_LIBRARIES := libcutils libc
 ################################
 
 OBJS = $(LOCAL_SRC_FILES:.cpp=.o) $(LOCAL_SRC_C_FILES:.c=.o)
-CXXFLAGS = -std=c++14 $(LOCAL_CFLAGS) $(LOCAL_INCLUDES)
-CFLAGS= $(LOCAL_CFLAGS) $(LOCAL_INCLUDES)
+CXXFLAGS = $(OPT_CXXFLAGS) -std=c++14 $(LOCAL_CFLAGS) $(LOCAL_INCLUDES)
+CFLAGS= $(OPT_CFLAGS) $(LOCAL_CFLAGS) $(LOCAL_INCLUDES)
 
 %.o: %.cpp
 	g++ -g -c -fPIC $(CXXFLAGS) $(LFLAGS) $< -o $@

--- a/base/Makefile
+++ b/base/Makefile
@@ -1,3 +1,7 @@
+top_srcdir ?= ..
+srcdir = $(top_srcdir)/base
+VPATH = $(srcdir)
+include $(top_srcdir)/include.mk
 
 targetSmpFlag := -DANDROID_SMP=1
 
@@ -29,13 +33,13 @@ LOCAL_CFLAGS += $(targetSmpFlag)
 ################################
 
 OBJS = $(LOCAL_SRC_FILES:.cpp=.o)
-CFLAGS = -std=c++0x $(LOCAL_CFLAGS) -I../include/ -Iinclude/ -I. -DHAVE_PTHREADS=1 -DADB_NON_ANDROID=1
-CFLAGS += -DPROP_NAME_MAX=32 -DPROP_VALUE_MAX=92
+CXXFLAGS = $(OPT_CXXFLAGS) -std=c++0x $(LOCAL_CFLAGS) -I$(top_srcdir)/include/ -I$(srcdir)/include -I$(srcdir) -DHAVE_PTHREADS=1 -DADB_NON_ANDROID=1
+CXXFLAGS += -DPROP_NAME_MAX=32 -DPROP_VALUE_MAX=92
 
 all: $(LOCAL_MODULE)
 
 %.o: %.cpp
-	g++ -g -c -fPIC $(CFLAGS) $(LFLAGS) $< -o $@
+	g++ -g -c -fPIC $(CXXFLAGS) $(LFLAGS) $< -o $@
 
 $(LOCAL_MODULE): $(OBJS)
 	ar rcs $@ $?

--- a/configure
+++ b/configure
@@ -1,0 +1,106 @@
+#!/bin/sh
+
+# This script provides basic compatibility with automake configure scripts
+# for use in automated build systems. See:
+#
+# https://people.gnome.org/~walters/docs/build-api.txt
+#
+
+print_help() {
+    echo "--prefix=DIR		Install files in DIR (default /usr)"
+    echo "--libdir=DIR		Install library files in DIR/tgt (default PREFIX/lib)"
+    echo "--sysconfdir=DIR	Install configuration files in DIR (default /etc)"
+    echo "--datadir=DIR		Install data files in DIR (default $PREFIX/share)"
+    echo "--mandir=DIR		Install configuration files in DIR (default DATADIR/man)"
+    echo "--docdir=DIR		Install documentation files in DIR (default DATADIR/doc/tgt)"
+    echo "--sbindir=DIR		Install binaries in DIR (default DATADIR/sbin)"
+    echo "--disable-man         Disable building and installing man pages"
+}
+
+top_srcdir=$(dirname $0)
+
+prefix=/usr
+exec_prefix='$(prefix)'
+bindir='$(prefix)/bin'
+sbindir='$(exec_prefix)/sbin'
+datadir='$(prefix)/share'
+mandir='$(datadir)/man'
+sysconfdir='$(prefix)/etc'
+CFLAGS='-O2 -g'
+CXXFLAGS='-O2 -g'
+
+while [ $# '>' 0 ] ; do
+    option=`expr "$1" : '\([^=]*\)='`
+    optarg=
+    consume_next=false
+    if [ x$option != x ]; then
+        optarg=`expr "$1" : '[^=]*=\(.*\)'`
+        shift
+    else
+        option=$1
+        shift
+        if expr "$option" : '-' > /dev/null ; then
+            consume_next=true
+            optarg=$1
+        fi
+    fi
+
+    case $option in
+        --prefix)
+            prefix=$optarg
+            ;;
+        --exec_prefix)
+            exec_prefix=$optarg
+            ;;
+        --sysconfdir)
+            sysconfdir=$optarg
+            ;;
+        --mandir)
+            mandir=$optarg
+            ;;
+        --datadir)
+            docdir=$optarg
+            ;;
+        --sbindir)
+            mandir=$optarg
+            ;;
+        CFLAGS)
+            CFLAGS=$optarg
+            ;;
+        CXXFLAGS)
+            CXXFLAGS=$optarg
+            ;;
+        --with-*|--without-*|--enable-*|--disable-*)
+            consume_next=false
+            ;;
+        --help)
+            print_help
+            exit
+            ;;
+    esac
+
+    if $consume_next ; then
+        shift
+    fi
+done
+
+cat > config.mk <<EOF
+prefix = $prefix
+exec_prefix = $exec_prefix
+sbindir = $sbindir
+bindir = $bindir
+datadir = $datadir
+mandir = $mandir
+sysconfdir = $sysconfdir
+OPT_CFLAGS = $CFLAGS
+OPT_CXXFLAGS = $CXXFLAGS
+EOF
+
+if [ "$(pwd)" != "$(cd $top_srcdir && pwd)" ] ; then
+    cat > Makefile <<EOF
+top_srcdir = $top_srcdir
+include \$(top_srcdir)/Makefile
+EOF
+fi
+
+make makefiles

--- a/include.mk
+++ b/include.mk
@@ -1,0 +1,12 @@
+top_builddir ?= $(top_srcdir)
+-include $(top_builddir)/config.mk
+
+prefix ?= /usr
+exec_prefix ?= $(prefix)
+bindir ?= $(prefix)/bin
+sbindir ?= $(exec_prefix)/sbin
+datadir ?= $(prefix)/share
+mandir ?= $(datadir)/man
+sysconfdir ?= $(prefix)/etc
+OPT_CFLAGS ?= -O2 -g
+OPT_CXXFLAGS ?= -O2 -g

--- a/libcrypto_utils/Makefile
+++ b/libcrypto_utils/Makefile
@@ -1,10 +1,15 @@
+top_srcdir ?= ..
+srcdir = $(top_srcdir)/libcrypto_utils
+VPATH = $(srcdir)
+include $(top_srcdir)/include.mk
+
 LOCAL_SRC_FILES = android_pubkey.c
 LOCAL_MODULE = libcrypto_utils.a
 
 ################################
 
 OBJS = $(LOCAL_SRC_FILES:.c=.o)
-CFLAGS = $(LOCAL_CFLAGS) -I../include/ -Iinclude/ -I. -DHAVE_PTHREADS=1 -DADB_NON_ANDROID=1
+CFLAGS = $(OPT_CFLAGS) $(LOCAL_CFLAGS) -I$(top_srcdir)/include/ -I$(srcdir)/include/ -I$(srcdir) -DHAVE_PTHREADS=1 -DADB_NON_ANDROID=1
 CFLAGS += -DPROP_NAME_MAX=32 -DPROP_VALUE_MAX=92
 
 all: $(LOCAL_MODULE)

--- a/libcutils/Makefile
+++ b/libcutils/Makefile
@@ -1,3 +1,7 @@
+top_srcdir ?= ..
+srcdir = $(top_srcdir)/libcutils
+VPATH = $(srcdir)
+include $(top_srcdir)/include.mk
 
 targetSmpFlag := -DANDROID_SMP=1
 
@@ -47,16 +51,18 @@ LOCAL_CFLAGS += $(targetSmpFlag)
 ################################
 
 OBJS = $(LOCAL_SRC_FILES:.c=.o) $(LOCAL_CXX_SRC_FILES:.cpp=.o)
-CFLAGS = $(LOCAL_CFLAGS) -I../include -I. -DHAVE_PTHREADS=1 -DADB_NON_ANDROID=1
-CFLAGS += -DPROP_NAME_MAX=32 -DPROP_VALUE_MAX=92
+EXTRA_CFLAGS = $(LOCAL_CFLAGS) -I$(top_srcdir)/include -I$(srcdir) -DHAVE_PTHREADS=1 -DADB_NON_ANDROID=1
+EXTRA_CFLAGS += -DPROP_NAME_MAX=32 -DPROP_VALUE_MAX=92
+CFLAGS = $(OPT_CFLAGS) $(EXTRA_CFLAGS)
+CXXFLAGS = $(OPT_CXXFLAGS) $(EXTRA_CFLAGS)
 
 all: $(LOCAL_MODULE)
 
 %.o: %.cpp
-	g++ -g -c -fPIC $(CFLAGS) $(LFLAGS) $< -o $@
+	g++ -c -fPIC $(CXXFLAGS) $(LFLAGS) $< -o $@
 
 %.o: %.c
-	gcc -g -c -fPIC $(CFLAGS) $(LFLAGS) $< -o $@
+	gcc -c -fPIC $(CFLAGS) $(LFLAGS) $< -o $@
 
 $(LOCAL_MODULE): $(OBJS)
 	ar rcs $@ $?


### PR DESCRIPTION
This pull request adds a configure script and srcdir != basedir building (using GNU make includes and some juggling), so that this can be built automatically in gnome-continuous.

It probably would have been about as much work to convert it to autoconf/automake, but this avoids adding dependencies and reduces the number of mystery files added to the tree.
