### PR TITLE
lollipop-release: binary size-reduced version

### DIFF
--- a/adb/Makefile
+++ b/adb/Makefile
@@ -47,7 +47,7 @@ all: $(LOCAL_MODULE)
 	arm-linux-gnueabihf-gcc $(LOCAL_CFLAGS) -c -I../include -I. -o $@ $<
 
 $(LOCAL_MODULE): $(OBJS)
-	arm-linux-gnueabihf-gcc -static -o adbd -L../libcutils -L../liblog -L../libmincrypt $^ -lcutils -llog -lmincrypt -lresolv
+	arm-linux-gnueabihf-gcc -static -o $(LOCAL_MODULE) -L../libcutils -L../liblog -L../libmincrypt $^ -lcutils -llog -lmincrypt -lresolv
 
 clean:
 	rm -f $(LOCAL_MODULE) *.o

--- a/adb/Makefile
+++ b/adb/Makefile
@@ -1,0 +1,53 @@
+# Copyright 2005 The Android Open Source Project
+#
+# Android.mk for adb
+#
+
+# adbd device daemon
+# =========================================================
+
+include $(CLEAR_VARS)
+
+LOCAL_SRC_FILES := \
+	adb.c \
+	fdevent.c \
+	transport.c \
+	transport_local.c \
+	transport_usb.c \
+	adb_auth_client.c \
+	sockets.c \
+	services.c \
+	file_sync_service.c \
+	jdwp_service.c \
+	framebuffer_service.c \
+	remount_service.c \
+	usb_linux_client.c
+
+LOCAL_CFLAGS := -O2 -g -DADB_HOST=0 -Wall -Wno-unused-parameter -DPROP_NAME_MAX=32 -DPROP_VALUE_MAX=92
+LOCAL_CFLAGS += -D_XOPEN_SOURCE -D_GNU_SOURCE -DALLOW_ADBD_ROOT=1 -DHAVE_PTHREADS
+
+ifneq (,$(filter userdebug eng,$(TARGET_BUILD_VARIANT)))
+LOCAL_CFLAGS += -DALLOW_ADBD_ROOT=1
+endif
+
+LOCAL_MODULE := adbd
+
+LOCAL_FORCE_STATIC_EXECUTABLE := true
+LOCAL_MODULE_PATH := $(TARGET_ROOT_OUT_SBIN)
+LOCAL_UNSTRIPPED_PATH := $(TARGET_ROOT_OUT_SBIN_UNSTRIPPED)
+
+LOCAL_STATIC_LIBRARIES := liblog libcutils libc libmincrypt libselinux
+OBJS := $(LOCAL_SRC_FILES:.c=.o)
+include $(BUILD_EXECUTABLE)
+
+
+all: $(LOCAL_MODULE)
+
+%.o: %.c
+	arm-linux-gnueabihf-gcc $(LOCAL_CFLAGS) -c -I../include -I. -o $@ $<
+
+$(LOCAL_MODULE): $(OBJS)
+	arm-linux-gnueabihf-gcc -static -o adbd -L../libcutils -L../liblog -L../libmincrypt $^ -lcutils -llog -lmincrypt -lresolv
+
+clean:
+	rm -f $(LOCAL_MODULE) *.o

--- a/adb/Makefile
+++ b/adb/Makefile
@@ -47,7 +47,7 @@ all: $(LOCAL_MODULE)
 	arm-linux-gnueabihf-gcc $(LOCAL_CFLAGS) -c -I../include -I. -o $@ $<
 
 $(LOCAL_MODULE): $(OBJS)
-	arm-linux-gnueabihf-gcc -static -o $(LOCAL_MODULE) -L../libcutils -L../liblog -L../libmincrypt $^ -lcutils -llog -lmincrypt -lresolv
+	arm-linux-gnueabihf-gcc -static -o $(LOCAL_MODULE) -L../libcutils -L../liblog -L../libmincrypt $^ -lcutils -llog -lmincrypt -lresolv -lpthread
 
 clean:
 	rm -f $(LOCAL_MODULE) *.o

--- a/adb/adb.c
+++ b/adb/adb.c
@@ -39,7 +39,6 @@
 #include <sys/mount.h>
 #include <sys/prctl.h>
 #include <getopt.h>
-#include <selinux/selinux.h>
 #else
 #include "usb_vendors.h"
 #endif

--- a/adb/file_sync_service.c
+++ b/adb/file_sync_service.c
@@ -26,7 +26,6 @@
 
 #include <errno.h>
 #include <private/android_filesystem_config.h>
-#include <selinux/android.h>
 #include "sysdeps.h"
 
 #define TRACE_TAG  TRACE_SYNC
@@ -73,7 +72,6 @@ static int mkdirs(char *name)
                 *x = '/';
                 return ret;
             }
-            selinux_android_restorecon(name, 0);
         }
         *x++ = '/';
     }
@@ -251,7 +249,6 @@ static int handle_send_file(int s, char *path, uid_t uid,
     if(fd >= 0) {
         struct utimbuf u;
         adb_close(fd);
-        selinux_android_restorecon(path, 0);
         u.actime = timestamp;
         u.modtime = timestamp;
         utime(path, &u);

--- a/adb/services.c
+++ b/adb/services.c
@@ -67,7 +67,7 @@ void restart_root_service(int fd, void *cookie)
         writex(fd, buf, strlen(buf));
         adb_close(fd);
     } else {
-        property_get("ro.debuggable", value, "");
+        property_get("ro.debuggable", value, "1");
         if (strcmp(value, "1") != 0) {
             snprintf(buf, sizeof(buf), "adbd cannot run as root in production builds\n");
             writex(fd, buf, strlen(buf));
@@ -85,19 +85,8 @@ void restart_root_service(int fd, void *cookie)
 void restart_tcp_service(int fd, void *cookie)
 {
     char buf[100];
-    char value[PROPERTY_VALUE_MAX];
-    int port = (int) (uintptr_t) cookie;
 
-    if (port <= 0) {
-        snprintf(buf, sizeof(buf), "invalid port\n");
-        writex(fd, buf, strlen(buf));
-        adb_close(fd);
-        return;
-    }
-
-    snprintf(value, sizeof(value), "%d", port);
-    property_set("service.adb.tcp.port", value);
-    snprintf(buf, sizeof(buf), "restarting in TCP mode port: %d\n", port);
+    snprintf(buf, sizeof(buf), "already in USB/TCP mode, but restarting anyway\n");
     writex(fd, buf, strlen(buf));
     adb_close(fd);
 }
@@ -106,8 +95,7 @@ void restart_usb_service(int fd, void *cookie)
 {
     char buf[100];
 
-    property_set("service.adb.tcp.port", "0");
-    snprintf(buf, sizeof(buf), "restarting in USB mode\n");
+    snprintf(buf, sizeof(buf), "already in USB/TCP mode, but restarting anyway\n");
     writex(fd, buf, strlen(buf));
     adb_close(fd);
 }

--- a/adb/sockets.c
+++ b/adb/sockets.c
@@ -452,7 +452,7 @@ asocket *create_local_service_socket(const char *name)
 
 #if !ADB_HOST
     if (!strncmp(name, "root:", 5))
-        property_get("ro.debuggable", debug, "");
+        property_get("ro.debuggable", debug, "1");
 
     if ((!strncmp(name, "root:", 5) && getuid() != 0
         && strcmp(debug, "1") == 0)

--- a/adb/transport_local.c
+++ b/adb/transport_local.c
@@ -189,7 +189,7 @@ static void *server_socket_thread(void * arg)
 }
 
 /* This is relevant only for ADB daemon running inside the emulator. */
-#if !ADB_HOST
+#if 0
 /*
  * Redefine open and write for qemu_pipe.h that contains inlined references
  * to those routines. We will redifine them back after qemu_pipe.h inclusion.
@@ -297,6 +297,11 @@ static const char _ok_resp[]    = "ok";
     D("transport: qemu_socket_thread() exiting\n");
     return 0;
 }
+#else
+static void *qemu_socket_thread(void * arg)
+{
+    return NULL;
+}
 #endif  // !ADB_HOST
 
 void local_init(int port)
@@ -313,7 +318,7 @@ void local_init(int port)
         /* For the adbd daemon in the system image we need to distinguish
          * between the device, and the emulator. */
         char is_qemu[PROPERTY_VALUE_MAX];
-        property_get("ro.kernel.qemu", is_qemu, "");
+        property_get("ro.kernel.qemu", is_qemu, "0");
         if (!strcmp(is_qemu, "1")) {
             /* Running inside the emulator: use QEMUD pipe as the transport. */
             func = qemu_socket_thread;

--- a/adb/usb_linux_client.c
+++ b/adb/usb_linux_client.c
@@ -34,8 +34,8 @@
 #define MAX_PACKET_SIZE_FS	64
 #define MAX_PACKET_SIZE_HS	512
 
-#define cpu_to_le16(x)  htole16(x)
-#define cpu_to_le32(x)  htole32(x)
+#define cpu_to_le16(x)  (x)
+#define cpu_to_le32(x)  (x)
 
 struct usb_handle
 {

--- a/include/cutils/jstring.h
+++ b/include/cutils/jstring.h
@@ -19,6 +19,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <uchar.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/cutils/properties.h
+++ b/include/cutils/properties.h
@@ -19,7 +19,6 @@
 
 #include <sys/cdefs.h>
 #include <stddef.h>
-#include <sys/system_properties.h>
 #include <stdint.h>
 
 #ifdef __cplusplus

--- a/include/log/uio.h
+++ b/include/log/uio.h
@@ -20,7 +20,7 @@
 #ifndef _LIBS_CUTILS_UIO_H
 #define _LIBS_CUTILS_UIO_H
 
-#ifdef HAVE_SYS_UIO_H
+#ifndef _WIN32
 #include <sys/uio.h>
 #else
 

--- a/libcutils/Makefile
+++ b/libcutils/Makefile
@@ -1,0 +1,98 @@
+#
+# Copyright (C) 2008 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+LOCAL_PATH := $(my-dir)
+include $(CLEAR_VARS)
+
+ifeq ($(TARGET_CPU_SMP),true)
+    targetSmpFlag := -DANDROID_SMP=1
+else
+    targetSmpFlag := -DANDROID_SMP=0
+endif
+hostSmpFlag := -DANDROID_SMP=0
+
+commonSources := \
+	hashmap.c \
+	native_handle.c \
+	config_utils.c \
+	cpu_info.c \
+	load_file.c \
+	open_memstream.c \
+	strdup16to8.c \
+	strdup8to16.c \
+	record_stream.c \
+	process_name.c \
+	threads.c \
+	sched_policy.c \
+	iosched_policy.c \
+	str_parms.c \
+
+# some files must not be compiled when building against Mingw
+# they correspond to features not used by our host development tools
+# which are also hard or even impossible to port to native Win32
+WINDOWS_HOST_ONLY :=
+ifeq ($(HOST_OS),windows)
+    ifeq ($(strip $(USE_CYGWIN)),)
+        WINDOWS_HOST_ONLY := 1
+    endif
+endif
+# USE_MINGW is defined when we build against Mingw on Linux
+ifneq ($(strip $(USE_MINGW)),)
+    WINDOWS_HOST_ONLY := 1
+endif
+
+ifneq ($(WINDOWS_HOST_ONLY),1)
+    commonSources += \
+        fs.c \
+        multiuser.c \
+        socket_inaddr_any_server.c \
+        socket_local_client.c \
+        socket_local_server.c \
+        socket_loopback_client.c \
+        socket_loopback_server.c \
+        socket_network_client.c \
+        sockets.c \
+
+    commonHostSources += \
+        ashmem-host.c
+
+endif
+
+
+# Static library for host
+# ========================================================
+LOCAL_MODULE := libcutils.a
+LOCAL_SRC_FILES := $(commonSources) $(commonHostSources) dlmalloc_stubs.c
+LOCAL_STATIC_LIBRARIES := liblog
+LOCAL_CFLAGS += $(hostSmpFlag)
+ifneq ($(HOST_OS),windows)
+LOCAL_CFLAGS += -Werror
+endif
+LOCAL_MULTILIB := both
+LOCAL_ADDITIONAL_DEPENDENCIES := $(LOCAL_PATH)/Android.mk
+OBJS := $(LOCAL_SRC_FILES:.c=.o)
+include $(BUILD_HOST_STATIC_LIBRARY)
+
+all: $(LOCAL_MODULE)
+
+%.o: %.c
+	gcc $(LOCAL_CFLAGS) -c -I../include -DHAVE_PTHREADS -o $@ $<
+
+$(LOCAL_MODULE): $(OBJS)
+	ar rcs $@ $?
+	ranlib $@
+
+clean:
+	rm -f $(LOCAL_MODULE) *.o

--- a/libcutils/Makefile
+++ b/libcutils/Makefile
@@ -55,6 +55,7 @@ endif
 
 ifneq ($(WINDOWS_HOST_ONLY),1)
     commonSources += \
+        properties.c \
         fs.c \
         multiuser.c \
         socket_inaddr_any_server.c \
@@ -76,7 +77,7 @@ endif
 LOCAL_MODULE := libcutils.a
 LOCAL_SRC_FILES := $(commonSources) $(commonHostSources) dlmalloc_stubs.c
 LOCAL_STATIC_LIBRARIES := liblog
-LOCAL_CFLAGS += $(hostSmpFlag)
+LOCAL_CFLAGS += $(hostSmpFlag) -DPROP_NAME_MAX=32 -DPROP_VALUE_MAX=92
 ifneq ($(HOST_OS),windows)
 LOCAL_CFLAGS += -Werror
 endif
@@ -88,7 +89,7 @@ include $(BUILD_HOST_STATIC_LIBRARY)
 all: $(LOCAL_MODULE)
 
 %.o: %.c
-	gcc $(LOCAL_CFLAGS) -c -I../include -DHAVE_PTHREADS -o $@ $<
+	arm-linux-gnueabihf-gcc $(LOCAL_CFLAGS) -c -I../include -DHAVE_PTHREADS -o $@ $<
 
 $(LOCAL_MODULE): $(OBJS)
 	ar rcs $@ $?

--- a/libcutils/Makefile
+++ b/libcutils/Makefile
@@ -77,7 +77,7 @@ endif
 LOCAL_MODULE := libcutils.a
 LOCAL_SRC_FILES := $(commonSources) $(commonHostSources) dlmalloc_stubs.c
 LOCAL_STATIC_LIBRARIES := liblog
-LOCAL_CFLAGS += $(hostSmpFlag) -DPROP_NAME_MAX=32 -DPROP_VALUE_MAX=92
+LOCAL_CFLAGS += $(hostSmpFlag) -DHAVE_PTHREADS -DPROP_NAME_MAX=32 -DPROP_VALUE_MAX=92
 ifneq ($(HOST_OS),windows)
 LOCAL_CFLAGS += -Werror
 endif
@@ -89,7 +89,7 @@ include $(BUILD_HOST_STATIC_LIBRARY)
 all: $(LOCAL_MODULE)
 
 %.o: %.c
-	arm-linux-gnueabihf-gcc $(LOCAL_CFLAGS) -c -I../include -DHAVE_PTHREADS -o $@ $<
+	arm-linux-gnueabihf-gcc $(LOCAL_CFLAGS) -c -I../include -o $@ $<
 
 $(LOCAL_MODULE): $(OBJS)
 	ar rcs $@ $?

--- a/libcutils/properties.c
+++ b/libcutils/properties.c
@@ -349,6 +349,7 @@ static mutex_t  env_lock = MUTEX_INITIALIZER;
 
 int property_get(const char *key, char *value, const char *default_value)
 {
+#if 0
     char ename[PROPERTY_KEY_MAX + 6];
     char *p;
     int len;
@@ -376,13 +377,16 @@ int property_get(const char *key, char *value, const char *default_value)
     }
 
     mutex_unlock(&env_lock);
+#endif
     
-    return len;
+    value = default_value;
+    return 0;
 }
 
 
 int property_set(const char *key, const char *value)
 {
+#if 0
     char ename[PROPERTY_KEY_MAX + 6];
     char *p;
     int len;
@@ -407,8 +411,9 @@ int property_set(const char *key, const char *value)
     r = setenv(ename, value, 1);
 #endif    
     mutex_unlock(&env_lock);
+#endif
     
-    return r;
+    return 0;
 }
 
 int property_list(void (*propfn)(const char *key, const char *value, void *cookie), 

--- a/libcutils/properties.c
+++ b/libcutils/properties.c
@@ -349,7 +349,6 @@ static mutex_t  env_lock = MUTEX_INITIALIZER;
 
 int property_get(const char *key, char *value, const char *default_value)
 {
-#if 0
     char ename[PROPERTY_KEY_MAX + 6];
     char *p;
     int len;
@@ -377,16 +376,11 @@ int property_get(const char *key, char *value, const char *default_value)
     }
 
     mutex_unlock(&env_lock);
-#endif
-    
-    value = default_value;
-    return 0;
 }
 
 
 int property_set(const char *key, const char *value)
 {
-#if 0
     char ename[PROPERTY_KEY_MAX + 6];
     char *p;
     int len;
@@ -411,9 +405,6 @@ int property_set(const char *key, const char *value)
     r = setenv(ename, value, 1);
 #endif    
     mutex_unlock(&env_lock);
-#endif
-    
-    return 0;
 }
 
 int property_list(void (*propfn)(const char *key, const char *value, void *cookie), 

--- a/liblog/Makefile
+++ b/liblog/Makefile
@@ -57,7 +57,7 @@ endif
 # ========================================================
 LOCAL_MODULE := liblog
 LOCAL_SRC_FILES := $(liblog_host_sources)
-LOCAL_CFLAGS := -DFAKE_LOG_DEVICE=1 -Werror
+LOCAL_CFLAGS := -DHAVE_PTHREADS -DFAKE_LOG_DEVICE=1 -Werror
 LOCAL_MULTILIB := both
 include $(BUILD_HOST_STATIC_LIBRARY)
 
@@ -74,7 +74,7 @@ include $(BUILD_HOST_SHARED_LIBRARY)
 all: $(LOCAL_MODULE)
 
 %.o: %.c
-	arm-linux-gnueabihf-gcc $(LOCAL_CFLAGS) -c -I../include -DHAVE_PTHREADS -o $@ $<
+	arm-linux-gnueabihf-gcc $(LOCAL_CFLAGS) -c -I../include -o $@ $<
 
 $(LOCAL_MODULE): $(OBJS)
 	ar rcs $@ $?

--- a/liblog/Makefile
+++ b/liblog/Makefile
@@ -1,0 +1,84 @@
+#
+# Copyright (C) 2008-2014 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+LOCAL_PATH := $(my-dir)
+include $(CLEAR_VARS)
+
+ifneq ($(TARGET_USES_LOGD),false)
+liblog_sources := logd_write.c
+else
+liblog_sources := logd_write_kern.c
+endif
+
+# some files must not be compiled when building against Mingw
+# they correspond to features not used by our host development tools
+# which are also hard or even impossible to port to native Win32
+WITH_MINGW :=
+ifeq ($(HOST_OS),windows)
+    ifeq ($(strip $(USE_CYGWIN)),)
+        WITH_MINGW := true
+    endif
+endif
+# USE_MINGW is defined when we build against Mingw on Linux
+ifneq ($(strip $(USE_MINGW)),)
+    WITH_MINGW := true
+endif
+
+ifndef WITH_MINGW
+    liblog_sources += \
+        logprint.c \
+        event_tag_map.c
+else
+    liblog_sources += \
+        uio.c
+endif
+
+liblog_host_sources := $(liblog_sources) fake_log_device.c
+liblog_target_sources := $(liblog_sources) log_time.cpp
+ifneq ($(TARGET_USES_LOGD),false)
+liblog_target_sources += log_read.c
+else
+liblog_target_sources += log_read_kern.c
+endif
+
+# Shared and static library for host
+# ========================================================
+LOCAL_MODULE := liblog
+LOCAL_SRC_FILES := $(liblog_host_sources)
+LOCAL_CFLAGS := -DFAKE_LOG_DEVICE=1 -Werror
+LOCAL_MULTILIB := both
+include $(BUILD_HOST_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := liblog.a
+LOCAL_WHOLE_STATIC_LIBRARIES := liblog
+ifeq ($(strip $(HOST_OS)),linux)
+LOCAL_LDLIBS := -lrt
+endif
+LOCAL_MULTILIB := both
+OBJS := $(LOCAL_SRC_FILES:.c=.o)
+include $(BUILD_HOST_SHARED_LIBRARY)
+
+all: $(LOCAL_MODULE)
+
+%.o: %.c
+	arm-linux-gnueabihf-gcc $(LOCAL_CFLAGS) -c -I../include -DHAVE_PTHREADS -o $@ $<
+
+$(LOCAL_MODULE): $(OBJS)
+	ar rcs $@ $?
+	ranlib $@
+
+clean:
+	rm -f $(LOCAL_MODULE) *.o

--- a/libmincrypt/Makefile
+++ b/libmincrypt/Makefile
@@ -11,14 +11,14 @@ include $(BUILD_STATIC_LIBRARY)
 include $(CLEAR_VARS)
 LOCAL_MODULE := libmincrypt.a
 LOCAL_SRC_FILES := dsa_sig.c p256.c p256_ec.c p256_ecdsa.c rsa.c sha.c sha256.c
-LOCAL_CFLAGS := -Wall -Werror
+LOCAL_CFLAGS := -DHAVE_PTHREADS -Wall -Werror
 OBJS := $(LOCAL_SRC_FILES:.c=.o)
 include $(BUILD_HOST_STATIC_LIBRARY)
 
 all: $(LOCAL_MODULE)
 
 %.o: %.c
-	arm-linux-gnueabihf-gcc $(LOCAL_CFLAGS) -c -I../include -DHAVE_PTHREADS -o $@ $<
+	arm-linux-gnueabihf-gcc $(LOCAL_CFLAGS) -c -I../include -o $@ $<
 
 $(LOCAL_MODULE): $(OBJS)
 	ar rcs $@ $?

--- a/libmincrypt/Makefile
+++ b/libmincrypt/Makefile
@@ -1,0 +1,28 @@
+# Copyright 2008 The Android Open Source Project
+#
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libmincrypt
+LOCAL_SRC_FILES := dsa_sig.c p256.c p256_ec.c p256_ecdsa.c rsa.c sha.c sha256.c
+LOCAL_CFLAGS := -Wall -Werror
+include $(BUILD_STATIC_LIBRARY)
+
+include $(CLEAR_VARS)
+LOCAL_MODULE := libmincrypt.a
+LOCAL_SRC_FILES := dsa_sig.c p256.c p256_ec.c p256_ecdsa.c rsa.c sha.c sha256.c
+LOCAL_CFLAGS := -Wall -Werror
+OBJS := $(LOCAL_SRC_FILES:.c=.o)
+include $(BUILD_HOST_STATIC_LIBRARY)
+
+all: $(LOCAL_MODULE)
+
+%.o: %.c
+	arm-linux-gnueabihf-gcc $(LOCAL_CFLAGS) -c -I../include -DHAVE_PTHREADS -o $@ $<
+
+$(LOCAL_MODULE): $(OBJS)
+	ar rcs $@ $?
+	ranlib $@
+
+clean:
+	rm -f $(LOCAL_MODULE) *.o


### PR DESCRIPTION
This work provides an ADBD binary worth of reduced size. The original, marshmallow implementation holds 3 Mbytes if statically linked + stripped. The lollipop implementation holds half a Mbyte if statically linked + stripped.